### PR TITLE
🔒 Fix Cross-Site Scripting (XSS) in OEmbed plugins

### DIFF
--- a/_plugins/facebook_oembed.rb
+++ b/_plugins/facebook_oembed.rb
@@ -1,6 +1,7 @@
 
 require 'oembed'
 require 'uri'
+require 'cgi'
 module Jekyll
   class FacebookEmbed < Liquid::Tag
 
@@ -10,7 +11,7 @@ module Jekyll
     end
 
     def render(context)
-      %{<div class="fb-post" data-href="#{@text}" data-width="500"></div>}
+      %{<div class="fb-post" data-href="#{CGI.escapeHTML(@text)}" data-width="500"></div>}
     end
   end
 end

--- a/_plugins/instagram_oembed.rb
+++ b/_plugins/instagram_oembed.rb
@@ -1,5 +1,6 @@
 require 'oembed'
 require 'uri'
+require 'cgi'
 module Jekyll
   class InstagramOEmbed < Liquid::Tag
 
@@ -9,7 +10,7 @@ module Jekyll
     end
 
     def render(context)
-      %{<iframe src="//instagram.com/p/#{@text}/embed/" width="445px" height="535px" frameborder="0" scrolling="no" allowtransparency="true"></iframe>}
+      %{<iframe src="//instagram.com/p/#{CGI.escapeHTML(@text)}/embed/" width="445px" height="535px" frameborder="0" scrolling="no" allowtransparency="true"></iframe>}
     end
   end
 end

--- a/_plugins/youtube_oembed.rb
+++ b/_plugins/youtube_oembed.rb
@@ -1,8 +1,9 @@
+require 'cgi'
 class YouTube < Liquid::Tag
 
   def initialize(tagName, markup, tokens)
     super
-    @url = "https://www.youtube.com/embed/#{markup.strip.chomp}"
+    @url = "https://www.youtube.com/embed/#{CGI.escapeHTML(markup.strip.chomp)}"
     @url << (@url.include?("?") ? "&" : "?")
     @url << "color=white&theme=light"
   end


### PR DESCRIPTION
🎯 **What:** Fixed multiple Cross-Site Scripting (XSS) vulnerabilities in the OEmbed plugins (`facebook_oembed.rb`, `instagram_oembed.rb`, and `youtube_oembed.rb`).
⚠️ **Risk:** User-provided input in Liquid tags was being directly interpolated into HTML attributes (`data-href`, `src`) without escaping. This allowed attackers to inject malicious JavaScript into the page by providing crafted input like `"><script>alert(1)</script>`.
🛡️ **Solution:** Integrated `CGI.escapeHTML` from the Ruby standard library to ensure all dynamic inputs are properly sanitized before being rendered in the HTML output.

---
*PR created automatically by Jules for task [12139523460197060777](https://jules.google.com/task/12139523460197060777) started by @jonatas*